### PR TITLE
完善文档注释,使得对IDE进行代码提示时更友好

### DIFF
--- a/src/DataMapper/DB/Data.php
+++ b/src/DataMapper/DB/Data.php
@@ -1,7 +1,9 @@
 <?php
-
 namespace Owl\DataMapper\DB;
 
+/**
+ * @method static \Owl\DataMapper\DB\Mapper getMapper()
+ */
 class Data extends \Owl\DataMapper\Data
 {
     protected static $mapper = '\Owl\DataMapper\DB\Mapper';

--- a/src/DataMapper/Data.php
+++ b/src/DataMapper/Data.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Owl\DataMapper;
 
 abstract class Data implements \JsonSerializable
@@ -17,10 +16,10 @@ abstract class Data implements \JsonSerializable
      * @var array
      */
     protected static $mapper_options = [
-        'service' => '',        // 存储服务名
-        'collection' => '',     // 存储集合名
-        'readonly' => false,    // 是否只读
-        'strict' => false,      // 是否所有属性默认开启严格模式
+        'service'    => '',    // 存储服务名
+        'collection' => '',    // 存储集合名
+        'readonly'   => false, // 是否只读
+        'strict'     => false, // 是否所有属性默认开启严格模式
     ];
 
     /**
@@ -51,34 +50,14 @@ abstract class Data implements \JsonSerializable
      */
     protected $dirty = [];
 
-    public function __beforeSave()
-    {
-    }
-    public function __afterSave()
-    {
-    }
-
-    public function __beforeInsert()
-    {
-    }
-    public function __afterInsert()
-    {
-    }
-
-    public function __beforeUpdate()
-    {
-    }
-    public function __afterUpdate()
-    {
-    }
-
-    public function __beforeDelete()
-    {
-    }
-    public function __afterDelete()
-    {
-    }
-
+    public function __beforeSave() {}
+    public function __afterSave() {}
+    public function __beforeInsert() {}
+    public function __afterInsert() {}
+    public function __beforeUpdate() {}
+    public function __afterUpdate() {}
+    public function __beforeDelete() {}
+    public function __afterDelete() {}
     /**
      * @param array [$values]
      * @param array [$options]
@@ -86,7 +65,7 @@ abstract class Data implements \JsonSerializable
     public function __construct(array $values = null, array $options = null)
     {
         $defaults = ['fresh' => true];
-        $options = $options ? array_merge($defaults, $options) : $defaults;
+        $options  = $options ? array_merge($defaults, $options) : $defaults;
 
         $attributes = static::getMapper()->getAttributes();
 
@@ -189,7 +168,7 @@ abstract class Data implements \JsonSerializable
             $found = false;
             foreach (array_keys(static::getMapper()->getAttributes()) as $akey) {
                 if ($key == str_replace('_', '', $akey)) {
-                    $key = $akey;
+                    $key   = $akey;
                     $found = true;
 
                     break;
@@ -214,12 +193,12 @@ abstract class Data implements \JsonSerializable
     {
         $this->fresh = true;
 
-        $mapper = static::getMapper();
+        $mapper     = static::getMapper();
         $attributes = $mapper->getAttributes();
 
         foreach ($this->values as $key => $value) {
             $attribute = $attributes[$key];
-            $type = Type::factory($attribute['type']);
+            $type      = Type::factory($attribute['type']);
 
             if ($attribute['primary_key']) {
                 if ($value = $type->getDefaultValue($attribute)) {
@@ -249,8 +228,8 @@ abstract class Data implements \JsonSerializable
     final public function __pack(array $values, $replace)
     {
         $this->values = $replace ? $values : array_merge($this->values, $values);
-        $this->dirty = [];
-        $this->fresh = false;
+        $this->dirty  = [];
+        $this->fresh  = false;
 
         return $this;
     }
@@ -289,7 +268,7 @@ abstract class Data implements \JsonSerializable
     public function set($key, $value, array $options = null)
     {
         $defaults = ['force' => false, 'strict' => true];
-        $options = $options ? array_merge($defaults, $options) : $defaults;
+        $options  = $options ? array_merge($defaults, $options) : $defaults;
 
         try {
             $attribute = $this->prepareSet($key, $options['force']);
@@ -345,7 +324,7 @@ abstract class Data implements \JsonSerializable
     public function get($key)
     {
         $attribute = $this->prepareGet($key);
-        $type = Type::factory($attribute['type']);
+        $type      = Type::factory($attribute['type']);
 
         if (!array_key_exists($key, $this->values)) {
             return $type->getDefaultValue($attribute);
@@ -355,6 +334,7 @@ abstract class Data implements \JsonSerializable
 
         // 当值是对象时，应该返回克隆对象而非原对象
         // 防止对象在外部被修改
+
         return $type->cloneValue($value);
     }
 
@@ -371,7 +351,7 @@ abstract class Data implements \JsonSerializable
         $this->prepareSet($key);
 
         $target = $this->get($key);
-        $path = (array) $path;
+        $path   = (array) $path;
 
         if (!is_array($target)) {
             throw new Exception\UnexpectedPropertyValueException(get_class($this).": Property {$key} is not complex type");
@@ -406,7 +386,7 @@ abstract class Data implements \JsonSerializable
         $this->prepareSet($key);
 
         $target = $this->get($key);
-        $path = (array) $path;
+        $path   = (array) $path;
 
         if (!is_array($target)) {
             throw new Exception\UnexpectedPropertyValueException(get_class($this).": Property {$key} is not complex type");
@@ -427,7 +407,7 @@ abstract class Data implements \JsonSerializable
     public function getIn($key, $path)
     {
         $target = $this->get($key);
-        $path = (array) $path;
+        $path   = (array) $path;
 
         if (!is_array($target)) {
             return false;
@@ -455,7 +435,7 @@ abstract class Data implements \JsonSerializable
     {
         if ($keys === null) {
             $attributes = static::getMapper()->getAttributes();
-            $keys = [];
+            $keys       = [];
 
             foreach ($attributes as $key => $attribute) {
                 if (!$attribute['protected']) {
@@ -466,7 +446,7 @@ abstract class Data implements \JsonSerializable
             $keys = is_array($keys) ? $keys : func_get_args();
         }
 
-        $values = array();
+        $values = [];
         foreach ($keys as $key) {
             if (array_key_exists($key, $this->values)) {
                 $values[$key] = $this->get($key);
@@ -484,10 +464,10 @@ abstract class Data implements \JsonSerializable
     public function toJSON()
     {
         $mapper = static::getMapper();
-        $json = [];
+        $json   = [];
 
         foreach ($this->toArray() as $key => $value) {
-            $attribute = $mapper->getAttribute($key);
+            $attribute  = $mapper->getAttribute($key);
             $json[$key] = Type::factory($attribute['type'])->toJSON($value, $attribute);
         }
 
@@ -535,8 +515,8 @@ abstract class Data implements \JsonSerializable
     public function isDirty($key = null)
     {
         return $key === null
-             ? (bool) $this->dirty
-             : isset($this->dirty[$key]);
+        ? (bool) $this->dirty
+        : isset($this->dirty[$key]);
     }
 
     /**
@@ -549,7 +529,7 @@ abstract class Data implements \JsonSerializable
     public function id($as_array = false)
     {
         $keys = static::getMapper()->getPrimaryKey();
-        $id = [];
+        $id   = [];
 
         foreach ($keys as $key) {
             $id[$key] = $this->get($key);
@@ -606,7 +586,7 @@ abstract class Data implements \JsonSerializable
     public function validate()
     {
         $attributes = static::getMapper()->getAttributes();
-        $keys = $this->isFresh() ? array_keys($attributes) : array_keys($this->dirty);
+        $keys       = $this->isFresh() ? array_keys($attributes) : array_keys($this->dirty);
 
         foreach ($keys as $key) {
             $attribute = $attributes[$key];
@@ -616,7 +596,7 @@ abstract class Data implements \JsonSerializable
             }
 
             $value = $this->get($key);
-            $type = Type::factory($attribute['type']);
+            $type  = Type::factory($attribute['type']);
 
             if ($type->isNull($value)) {
                 if (!$attribute['allow_null']) {
@@ -706,7 +686,7 @@ abstract class Data implements \JsonSerializable
     final protected function change($key, $value, array $attribute = null)
     {
         $attribute = $attribute ?: static::getMapper()->getAttribute($key);
-        $type = Type::factory($attribute['type']);
+        $type      = Type::factory($attribute['type']);
 
         if (array_key_exists($key, $this->values)) {
             if ($value === $this->values[$key]) {
@@ -719,7 +699,7 @@ abstract class Data implements \JsonSerializable
         }
 
         $this->values[$key] = $value;
-        $this->dirty[$key] = true;
+        $this->dirty[$key]  = true;
     }
 
     /**
@@ -727,7 +707,7 @@ abstract class Data implements \JsonSerializable
      *
      * @param mixed $id
      *
-     * @return Data|false
+     * @return static|false
      */
     public static function find($id)
     {
@@ -739,7 +719,8 @@ abstract class Data implements \JsonSerializable
      *
      * @param mixed $id
      *
-     * @return Data
+     * @return static
+     * @throws Exception\DataNotFoundException
      */
     public static function findOrFail($id)
     {
@@ -776,7 +757,7 @@ abstract class Data implements \JsonSerializable
      */
     final public static function getOptions()
     {
-        $options = static::$mapper_options;
+        $options               = static::$mapper_options;
         $options['attributes'] = static::$attributes;
 
         $called_class = get_called_class();
@@ -784,11 +765,11 @@ abstract class Data implements \JsonSerializable
             return $options;
         }
 
-        $parent_class = get_parent_class($called_class);
+        $parent_class   = get_parent_class($called_class);
         $parent_options = $parent_class::getOptions();
 
         $options['attributes'] = array_merge($parent_options['attributes'], $options['attributes']);
-        $options = array_merge($parent_options, $options);
+        $options               = array_merge($parent_options, $options);
 
         return $options;
     }

--- a/src/DataMapper/Mapper.php
+++ b/src/DataMapper/Mapper.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Owl\DataMapper;
 
 abstract class Mapper
@@ -67,38 +66,18 @@ abstract class Mapper
      */
     public function __construct($class)
     {
-        $this->class = $class;
+        $this->class   = $class;
         $this->options = array_merge($this->normalizeOptions($class::getOptions()), $this->options);
     }
 
-    protected function __beforeSave(\Owl\DataMapper\Data $data)
-    {
-    }
-    protected function __afterSave(\Owl\DataMapper\Data $data)
-    {
-    }
-
-    protected function __beforeInsert(\Owl\DataMapper\Data $data)
-    {
-    }
-    protected function __afterInsert(\Owl\DataMapper\Data $data)
-    {
-    }
-
-    protected function __beforeUpdate(\Owl\DataMapper\Data $data)
-    {
-    }
-    protected function __afterUpdate(\Owl\DataMapper\Data $data)
-    {
-    }
-
-    protected function __beforeDelete(\Owl\DataMapper\Data $data)
-    {
-    }
-    protected function __afterDelete(\Owl\DataMapper\Data $data)
-    {
-    }
-
+    protected function __beforeSave(\Owl\DataMapper\Data $data) {}
+    protected function __afterSave(\Owl\DataMapper\Data $data) {}
+    protected function __beforeInsert(\Owl\DataMapper\Data $data) {}
+    protected function __afterInsert(\Owl\DataMapper\Data $data) {}
+    protected function __beforeUpdate(\Owl\DataMapper\Data $data) {}
+    protected function __afterUpdate(\Owl\DataMapper\Data $data) {}
+    protected function __beforeDelete(\Owl\DataMapper\Data $data) {}
+    protected function __afterDelete(\Owl\DataMapper\Data $data) {}
     final private function __before($event, \Owl\DataMapper\Data $data)
     {
         $event = ucfirst($event);
@@ -156,7 +135,7 @@ abstract class Mapper
     /**
      * 获得存储服务连接实例.
      *
-     * @return Owl\Service
+     * @return \Owl\Service
      *
      * @throws \RuntimeException Data class没有配置存储服务
      */
@@ -204,8 +183,8 @@ abstract class Mapper
     public function getAttribute($key)
     {
         return isset($this->options['attributes'][$key])
-             ? $this->options['attributes'][$key]
-             : false;
+        ? $this->options['attributes'][$key]
+        : false;
     }
 
     /**
@@ -269,7 +248,7 @@ abstract class Mapper
      */
     public function pack(array $record, Data $data = null)
     {
-        $types = Type::getInstance();
+        $types  = Type::getInstance();
         $values = [];
 
         $attributes = $this->getAttributes();
@@ -279,7 +258,7 @@ abstract class Mapper
                 continue;
             }
 
-            $attribute = $attributes[$key];
+            $attribute    = $attributes[$key];
             $values[$key] = $types->get($attribute['type'])->restore($value, $attribute);
         }
 
@@ -287,7 +266,7 @@ abstract class Mapper
             $data->__pack($values, false);
         } else {
             $class = $this->class;
-            $data = new $class(null, ['fresh' => false]);
+            $data  = new $class(null, ['fresh' => false]);
             $data->__pack($values, true);
         }
 
@@ -305,7 +284,7 @@ abstract class Mapper
     public function unpack(Data $data, array $options = null)
     {
         $defaults = ['dirty' => false];
-        $options = $options ? array_merge($defaults, $options) : $defaults;
+        $options  = $options ? array_merge($defaults, $options) : $defaults;
 
         $attributes = $this->getAttributes();
 
@@ -317,7 +296,7 @@ abstract class Mapper
 
             if ($value !== null) {
                 $attribute = $attributes[$key];
-                $value = Type::factory($attribute['type'])->store($value, $attribute);
+                $value     = Type::factory($attribute['type'])->store($value, $attribute);
             }
 
             $record[$key] = $value;
@@ -484,11 +463,11 @@ abstract class Mapper
     protected function normalizeOptions(array $options)
     {
         $options = array_merge([
-            'service' => null,
+            'service'    => null,
             'collection' => null,
             'attributes' => [],
-            'readonly' => false,
-            'strict' => false,
+            'readonly'   => false,
+            'strict'     => false,
         ], $options);
 
         $primary_key = [];

--- a/src/DataMapper/Mongo/Data.php
+++ b/src/DataMapper/Mongo/Data.php
@@ -1,7 +1,9 @@
 <?php
-
 namespace Owl\DataMapper\Mongo;
 
+/**
+ * @method static \Owl\DataMapper\Mongo\Mapper getMapper()
+ */
 class Data extends \Owl\DataMapper\Data
 {
     protected static $mapper = '\Owl\DataMapper\Mongo\Mapper';

--- a/src/DataMapper/Registry.php
+++ b/src/DataMapper/Registry.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Owl\DataMapper;
 
 class Registry
@@ -64,14 +63,14 @@ class Registry
             return false;
         }
 
-        $key = self::key($class, $id);
+        $key                 = self::key($class, $id);
         $this->members[$key] = $data;
     }
 
     /**
      * 根据类名和主键值，获得缓存结果.
      *
-     * @param string class
+     * @param string $class
      * @param string|int|array $id
      *
      * @return Data|false
@@ -85,8 +84,8 @@ class Registry
         $key = self::key($class, $id);
 
         return isset($this->members[$key])
-             ? $this->members[$key]
-             : false;
+        ? $this->members[$key]
+        : false;
     }
 
     /**
@@ -110,7 +109,7 @@ class Registry
      */
     public function clear()
     {
-        $this->members = array();
+        $this->members = [];
     }
 
     /**


### PR DESCRIPTION
在实际开发中Entity::find和findOrFail方法时,由于文档注释中的返回类型为Data,导致IDE不能很好的进行代码提示(在IDE仅仅会提示Data的方法,而不是具体Entity中的方法)
同样的还有getMapper方法,由于无法指导IDE识别正确的Mapper类,从而也无法对Select类进行正确的代码提示.

这个pull request中的仅仅在部分地方加入了文档注释,并没修改任何代码逻辑